### PR TITLE
test case for like operand type missmatch

### DIFF
--- a/src/main/java/org/shreeram/qksupdate/entity/Person.java
+++ b/src/main/java/org/shreeram/qksupdate/entity/Person.java
@@ -1,9 +1,6 @@
 package org.shreeram.qksupdate.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,7 +11,8 @@ import lombok.NoArgsConstructor;
 public class Person {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "person_id_seq")
+    @SequenceGenerator(name = "person_id_seq", sequenceName = "person_id_seq", allocationSize = 1)
     private Long id;
     private String name;
     private String city;

--- a/src/test/java/org/shreeram/qksupdate/repository/PersonRepositoryTest.java
+++ b/src/test/java/org/shreeram/qksupdate/repository/PersonRepositoryTest.java
@@ -102,4 +102,12 @@ class PersonRepositoryTest {
 //        assertEquals(managed.getId(),detached.getId());
 //        assertEquals("Haryana",detached.getCity());
     }
+
+    @Test
+    void givenString_whenFunctionInHQL_returnsFormattedString(){
+        var hql = "from Person p where function('replace',city,'#',' ') like '%n'";
+        var result = repository.getEntityManager().createQuery(hql,Person.class).getResultList().stream().findFirst();
+        assertNotNull(result);
+        result.ifPresent(System.out::println);
+    }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,6 +10,7 @@ quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5433/hibernate_db
 # drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.log.format-sql=true
 
 # inmemory datasource configuration
 #quarkus.datasource.db-kind=h2

--- a/src/test/resources/import.sql
+++ b/src/test/resources/import.sql
@@ -1,0 +1,1 @@
+INSERT INTO upgrade.person (id,name, city) VALUES (nextval('person_id_seq'),'frank', 'i#am#in#basildon');


### PR DESCRIPTION
add a test case to check like operand type missmatch issue on quarkus 3.2 and 3.15 versions
it required to have  an existing person record 
but the respecitve entity id/primary key has identity strategy , which mandates to have id field value on each insert
to resolve this made id field generative with sequence type
also , put import.sql script with  a row insert statement which populates person table with a single row 