### PR TITLE
update logging configurations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db:
     image: postgres:12.22-alpine3.21

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,14 @@
 quarkus.datasource.db-kind = postgresql
 quarkus.datasource.username = postgres
 quarkus.datasource.password = password
-quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5433/hibernate_db
+quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5433/hnt_db
 
 # drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.database.generation=drop-and-create
+
+# logging
+quarkus.log.console.level=DEBUG
+quarkus.log.min-level=TRACE
+quarkus.console.color=true
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.log.bind-parameters=true

--- a/src/test/java/org/shreeram/qksupdate/repository/PersonRepositoryTest.java
+++ b/src/test/java/org/shreeram/qksupdate/repository/PersonRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.shreeram.qksupdate.entity.Person;
 import org.shreeram.qksupdate.helper.PersonHelper;
 import org.shreeram.qksupdate.mapper.PersonMapper;
+import io.quarkus.logging.Log;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -86,7 +87,7 @@ class PersonRepositoryTest {
         Exception e = assertThrows(PersistenceException.class,
                 ()->  repository.add(entity),
                 ()->"unmanaged/detached/non-persistent entity cannot be persisted/inserted/updated") ;
-        System.out.println("type: "+e.getClass().getName()+", message: "+e.getMessage());
+        Log.errorv("type: {0}, message: {1}",e.getClass().getName(),e.getMessage());
     }
 
     @Test/*given domain with id , should not update unmanaged entity (persist)*/
@@ -98,12 +99,14 @@ class PersonRepositoryTest {
         var managed = repository.getEntityManager().find(Person.class,entity.getId());
         assertNotNull(managed);
         var unmanaged= new Person();
+        Log.infov("is persistent: {0}",repository.isPersistent(unmanaged));
         unmanaged.setId(managed.getId());
+        Log.infov("is persistent: {0}",repository.isPersistent(unmanaged));
         unmanaged.setCity("Haryana");
         Exception e = assertThrows(PersistenceException.class,
                 ()->  repository.add(unmanaged),
                 ()->"unmanaged/detached/non-persistent entity cannot be persisted/inserted/updated") ;
-        System.out.println("type: "+e.getClass().getName()+", message: "+e.getMessage());
+        Log.errorv("type: {0}, message: {1}",e.getClass().getName(),e.getMessage());
     }
 
     @Test
@@ -114,6 +117,6 @@ class PersonRepositoryTest {
                 .setMaxResults(1)
                 .getSingleResult();
         assertNotNull(result);
-        System.out.println(result);
+        Log.infov("found {0}",result);
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,16 +1,11 @@
-quarkus.http.test-port=8083
-quarkus.http.test-ssl-port=8446
-quarkus.http.test-timeout=10s
 # datasource configuration
 quarkus.datasource.db-kind = postgresql
 quarkus.datasource.username = postgres
 quarkus.datasource.password = password
-quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5433/hibernate_db
+quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5433/test
 
 # drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.hibernate-orm.log.sql=true
-quarkus.hibernate-orm.log.format-sql=true
 
 # inmemory datasource configuration
 #quarkus.datasource.db-kind=h2


### PR DESCRIPTION
added logs in unit test cases, but only info and below( warning, error,..) logging are visible at the console level
using io.quarkus.logging.Log for logging 
docker-compose version property has been obsolete hence removed